### PR TITLE
Added highlighting support for tabu package evns

### DIFF
--- a/syntax/LaTeX.tmLanguage.json
+++ b/syntax/LaTeX.tmLanguage.json
@@ -817,7 +817,7 @@
       ]
     },
     {
-      "begin": "(?:\\s*)((\\\\)begin)(\\{)(tabular[xy*]?|xltabular|longtable)(\\})(\\s*\\n)?",
+      "begin": "(?:\\s*)((\\\\)begin)(\\{)(tabular[xy*]?|xltabular|longtable|(long)?tabu)(\\})(\\s*\\n)?",
       "captures": {
         "1": {
           "name": "support.function.be.latex"


### PR DESCRIPTION
Changed the regular expression for "meta.function.environment.tabular.latex" to match against the `tabu` and `longtabu` environments. This enables proper highlighting of table cell dividers as such:

![grafik](https://user-images.githubusercontent.com/34143268/118380825-32d6ac80-b5e5-11eb-877e-e6e60bb40dd0.png)
